### PR TITLE
fix json negative prompt text output

### DIFF
--- a/save_image_extended.py
+++ b/save_image_extended.py
@@ -236,7 +236,7 @@ class SaveImageExtended:
 										if isinstance(negative_text[0], str) and len(negative_text[0]) < 6:
 											if isinstance(negative_text[1], (int, float)):
 												continue
-								prompt_keys_to_save['positive_prompt'] = negative_text
+								prompt_keys_to_save['negative_prompt'] = negative_text
 
 		# Append data and save
 		json_file_path = os.path.join(output_path, filename)


### PR DESCRIPTION
h/t @addiGeometry https://github.com/thedyze/save-image-extended-comfyui/issues/13#issuecomment-1963804731

---

This PR resolves https://github.com/thedyze/save-image-extended-comfyui/issues/13, where `negative_text` was used to populate the `positive_prompt` field instead of `negative_prompt`.